### PR TITLE
Nerfs Stunbatons/Stunprods

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -12,7 +12,7 @@
 	attack_verb = list("beaten")
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 80)
 
-	var/stunforce = 140
+	var/stunforce = 75
 	var/status = 0
 	var/obj/item/stock_parts/cell/cell
 	var/hitcost = 1000
@@ -192,7 +192,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	force = 3
 	throwforce = 5
-	stunforce = 100
+	stunforce = 5
 	hitcost = 2000
 	throw_hit_chance = 10
 	slot_flags = ITEM_SLOT_BACK


### PR DESCRIPTION

## About The Pull Request
Halfes stunbaton/stunprod stun duration.

## Why It's Good For The Game

Makes stunbatons fair and balanced.

## Changelog

Stunbaton stun duration from 14 seconds ro 7.5 seconds
Stunprod stun duration from 10 seconds to 5 seconds.